### PR TITLE
Update lua_ref_table.hpp

### DIFF
--- a/include/kaguya/lua_ref_table.hpp
+++ b/include/kaguya/lua_ref_table.hpp
@@ -116,6 +116,19 @@ namespace kaguya
 		friend class LuaRef;
 		friend class State;
 
+#if KAGUYA_USE_RVALUE_REFERENCE
+		TableKeyReference(TableKeyReference&& src)throw() :LuaRef(), parent_(), key_()
+		{
+			swap(src);
+		}
+
+		TableKeyReference& operator=(TableKeyReference&& src)
+		{
+			swap(src);
+			return *this;
+		}
+#endif
+
 		//! this is not copy.same assign from LuaRef.
 		TableKeyReference& operator=(const TableKeyReference& src)
 		{
@@ -200,12 +213,6 @@ namespace kaguya
 			std::swap(parent_, other.parent_);
 			std::swap(key_, other.key_);
 		}
-#if KAGUYA_USE_RVALUE_REFERENCE
-		TableKeyReference(TableKeyReference&& src)throw() :LuaRef(), parent_(), key_()
-		{
-			swap(src);
-		}
-#endif
 
 		LuaTable parent_;
 		LuaRef key_;


### PR DESCRIPTION
Moved move constructor and assignment to public visibility.
Otherwise it makes error on code like kaguya::TableKeyReference test = state["test"];