### PR TITLE
Remove superfluous commas and semicolons

### DIFF
--- a/include/kaguya/detail/lua_function_def.hpp
+++ b/include/kaguya/detail/lua_function_def.hpp
@@ -314,7 +314,7 @@ namespace kaguya
 			COSTAT_RUNNING,//!< coroutine is running
 			COSTAT_SUSPENDED,//!< coroutine is suspended
 			COSTAT_NORMAL,//!<
-			COSTAT_DEAD,//!< coroutine is dead
+			COSTAT_DEAD//!< coroutine is dead
 		};
 
 		/**

--- a/include/kaguya/error_handler.hpp
+++ b/include/kaguya/error_handler.hpp
@@ -224,4 +224,4 @@ namespace kaguya
 			return true;
 		}
 	}
-};
+}

--- a/include/kaguya/metatable.hpp
+++ b/include/kaguya/metatable.hpp
@@ -481,4 +481,4 @@ namespace kaguya
 		MemberMapType member_map_;
 		CodeChunkMapType code_chunk_map_;
 	};
-};
+}

--- a/include/kaguya/native_function.hpp
+++ b/include/kaguya/native_function.hpp
@@ -470,7 +470,7 @@ namespace kaguya
 			KAGUYA_PP_REPEAT(N,KAGUYA_PUSH_DEF);\
 			return v;\
 		}
-	KAGUYA_PP_REPEAT_DEF(9, KAGUYA_FOVERLOAD_DEF);
+	KAGUYA_PP_REPEAT_DEF(9, KAGUYA_FOVERLOAD_DEF)
 #undef KAGUYA_DEF_TEMPLATE
 #undef KAGUYA_PUSH_DEF
 #undef KAGUYA_FOVERLOAD_DEF
@@ -544,4 +544,4 @@ namespace kaguya
 		}
 	};
 
-};
+}

--- a/include/kaguya/object.hpp
+++ b/include/kaguya/object.hpp
@@ -666,4 +666,4 @@ namespace kaguya
 		}
 		return standard::shared_ptr<T>();
 	}
-};
+}

--- a/include/kaguya/ref_tuple.hpp
+++ b/include/kaguya/ref_tuple.hpp
@@ -10,4 +10,4 @@
 namespace kaguya
 {
 #include "kaguya/gen/ref_tuple.inl"
-};
+}

--- a/include/kaguya/state.hpp
+++ b/include/kaguya/state.hpp
@@ -20,7 +20,7 @@ namespace kaguya
 {
 	typedef std::pair<std::string, lua_CFunction> LoadLib;
 	typedef std::vector<LoadLib> LoadLibs;
-	inline LoadLibs NoLoadLib() { return LoadLibs(); };
+	inline LoadLibs NoLoadLib() { return LoadLibs(); }
 
 	template<typename Allocator>
 	void * AllocatorFunction(void *ud,
@@ -527,4 +527,4 @@ namespace kaguya
 		*/
 		lua_State *state() { return state_; };
 	};
-};
+}

--- a/include/kaguya/traits.hpp
+++ b/include/kaguya/traits.hpp
@@ -94,4 +94,4 @@ namespace kaguya
 	struct is_usertype : traits::integral_constant<bool, false> {};
 	template< typename T>
 	struct is_usertype<T, typename lua_type_traits<T>::Registerable> : traits::integral_constant<bool, true> {};
-};
+}

--- a/include/kaguya/type.hpp
+++ b/include/kaguya/type.hpp
@@ -636,7 +636,7 @@ namespace kaguya
 			TYPE_TABLE = LUA_TTABLE,//!< table type
 			TYPE_FUNCTION = LUA_TFUNCTION,//!< function type
 			TYPE_USERDATA = LUA_TUSERDATA,//!< userdata type
-			TYPE_THREAD = LUA_TTHREAD,//!< thread(coroutine) type
+			TYPE_THREAD = LUA_TTHREAD//!< thread(coroutine) type
 		};
 
 		bool isNilref_()const {
@@ -859,4 +859,4 @@ namespace kaguya
 		return !(rhs == lhs);
 	}
 	//@}
-};
+}


### PR DESCRIPTION
I got some compilation problems for an apple cross-compiler that reports extra commas and semicolons as errors.
This removes those to make it compile there