### PR TITLE
Improve variadic arg overload resolution

### DIFF
--- a/include/kaguya/detail/lua_table_def.hpp
+++ b/include/kaguya/detail/lua_table_def.hpp
@@ -227,9 +227,9 @@ namespace kaguya
 			util::ScopedSavedStack save(state_());
 			int stackIndex = pushStackIndex_(state_());
 #if LUA_VERSION_NUM >= 502
-			int size = lua_rawlen(state_(), stackIndex);
+			size_t size = lua_rawlen(state_(), stackIndex);
 #else
-			int size = lua_objlen(state_(), stackIndex);
+			size_t size = lua_objlen(state_(), stackIndex);
 #endif
 			res.reserve(size);
 			foreach_table<void, V>(gettablevalue<V>(res));

--- a/include/kaguya/lua_ref_table.hpp
+++ b/include/kaguya/lua_ref_table.hpp
@@ -349,7 +349,6 @@ namespace kaguya
 	LuaStackRef LuaTableOrUserDataImpl<T>::getField(const KEY& key)const
 	{
 		lua_State* state = state_();
-		typedef typename lua_type_traits<T>::get_type get_type;
 		if (!state)
 		{
 			except::typeMismatchError(state, "is nil");

--- a/include/kaguya/native_function.hpp
+++ b/include/kaguya/native_function.hpp
@@ -275,6 +275,7 @@ namespace kaguya
 			}
 			FunctorType* weak_match = 0;
 			FunctorType* argcount_unmatch = 0;
+			int minArgDiv = 0;
 			for (int i = 0; i < overloadnum; ++i)
 			{
 				FunctorType* fun = static_cast<FunctorType*>(lua_touserdata(l, lua_upvalueindex(i + 2)));
@@ -283,20 +284,21 @@ namespace kaguya
 					continue;
 				}
 				int fnarg = (*fun)->argsCount();
-				bool match_argcount = fnarg == argcount;
-				if (match_argcount && (*fun)->checktype(l, true))
+				int argDiv = argcount - fnarg;
+				if (!argDiv && (*fun)->checktype(l, true))
 				{
 					return fun;
 				}
-				else if (weak_match == 0 && (match_argcount || !argcount_unmatch) && (*fun)->checktype(l, false))
+				else if (!weak_match && (!argDiv || !argcount_unmatch || argDiv < minArgDiv) && (*fun)->checktype(l, false))
 				{
-					if (match_argcount)
+					if (!argDiv)
 					{
 						weak_match = fun;
 					}
 					else
 					{
 						argcount_unmatch = fun;
+                        minArgDiv = argDiv;
 					}
 				}
 			}

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1010,7 +1010,14 @@ namespace t_03_function
 
 		TEST_CHECK(ptr);
 		TEST_EQUAL(ptr->args[0].get<std::string>(), "abc");
-	}
+
+		state("var = Vari.new('abc', 'def')");
+		ptr = state["var"];
+
+		TEST_CHECK(ptr);
+		TEST_EQUAL(ptr->args[0].get<std::string>(), "abc");
+		TEST_EQUAL(ptr->args[1].get<std::string>(), "def");
+    }
 
 
 


### PR DESCRIPTION
The overload resolution has an issue: It can match the wrong function especially when variadic args are used. I extended the test case to provoke a failure without this patch.
The idea is to match the function with the least param count difference.

In this case: 2 Ctors. 1st with 0 params, 2nd with 1 varArgs param. Invoked with 2 params -> diff0 = 2-0=2, diff1 = 2-1=1 -> 2nd overload is taken.
However this fails for the opposite case: 1st ctor has 3 params -> Would match this as difference is -1
But I think this is ok as the varargs function should be the one with the most params anyway.

This can still be improved by explicitly checking for a varagrs function and taking that if no function with matching param count is found. But this requires some template trickery which I don't know where to add