### PR TITLE
Fix checking of const function types

### DIFF
--- a/include/kaguya/native_function.hpp
+++ b/include/kaguya/native_function.hpp
@@ -114,7 +114,7 @@ namespace kaguya
 		// for data member
 		//using is_member_function_pointer in MSVC2010 : fatal error LNK1179: invalid or corrupt file: duplicate COMDAT '?value@?$result_@P8ABC@test_02_classreg@@AE?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@XZ@?$is_mem_fun_pointer_select@$0A@@detail@boost@@2_NB'
 		template<class MemType, class T>
-		typename traits::enable_if<traits::is_object<MemType>::value, int>::type
+		typename traits::enable_if<traits::is_member_object_pointer<MemType T::*>::value, int>::type
 		call(lua_State* state, MemType T::* mptr)
 		{
 			T* this_ = lua_type_traits<T*>::get(state, 1);
@@ -155,7 +155,7 @@ namespace kaguya
 			}
 		}
 		template<class MemType, class T>
-		typename traits::enable_if<traits::is_object<MemType>::value, bool>::type
+		typename traits::enable_if<traits::is_member_object_pointer<MemType T::*>::value, bool>::type
 		checkArgTypes(lua_State* state, MemType T::* mptr, int opt_count = 0)
 		{
 			if (lua_gettop(state) >= 2)
@@ -167,7 +167,7 @@ namespace kaguya
 			return  lua_type_traits<T>::checkType(state, 1);
 		}
 		template<class MemType, class T>
-		typename traits::enable_if<traits::is_object<MemType>::value, bool>::type
+		typename traits::enable_if<traits::is_member_object_pointer<MemType T::*>::value, bool>::type
 		 strictCheckArgTypes(lua_State* state, MemType T::* mptr, int opt_count = 0)
 		{
 			if (lua_gettop(state) == 2)
@@ -179,19 +179,19 @@ namespace kaguya
 			return  lua_type_traits<T>::strictCheckType(state, 1);
 		}
 		template<class MemType, class T>
-		typename traits::enable_if<traits::is_object<MemType>::value, std::string>::type
+		typename traits::enable_if<traits::is_member_object_pointer<MemType T::*>::value, std::string>::type
 		argTypesName(MemType T::* mptr)
 		{
 			return util::pretty_name(typeid(T*)) + ",[OPT] " + util::pretty_name(typeid(MemType));
 		}
 		template<class MemType, class T>
-		typename traits::enable_if<traits::is_object<MemType>::value, int>::type
+		typename traits::enable_if<traits::is_member_object_pointer<MemType T::*>::value, int>::type
 		minArgCount(MemType T::* mptr)
 		{
 			return 1;
 		}
 		template<class MemType, class T>
-		typename traits::enable_if<traits::is_object<MemType>::value, int>::type
+		typename traits::enable_if<traits::is_member_object_pointer<MemType T::*>::value, int>::type
 		maxArgCount(MemType T::* mptr)
 		{
 			return 2;

--- a/include/kaguya/native_function.hpp
+++ b/include/kaguya/native_function.hpp
@@ -114,7 +114,7 @@ namespace kaguya
 		// for data member
 		//using is_member_function_pointer in MSVC2010 : fatal error LNK1179: invalid or corrupt file: duplicate COMDAT '?value@?$result_@P8ABC@test_02_classreg@@AE?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@XZ@?$is_mem_fun_pointer_select@$0A@@detail@boost@@2_NB'
 		template<class MemType, class T>
-		typename traits::enable_if<traits::is_member_object_pointer<MemType T::*>::value, int>::type
+		typename traits::enable_if<traits::is_object<MemType>::value, int>::type
 		call(lua_State* state, MemType T::* mptr)
 		{
 			T* this_ = lua_type_traits<T*>::get(state, 1);
@@ -155,7 +155,7 @@ namespace kaguya
 			}
 		}
 		template<class MemType, class T>
-		typename traits::enable_if<traits::is_member_object_pointer<MemType T::*>::value, bool>::type
+		typename traits::enable_if<traits::is_object<MemType>::value, bool>::type
 		checkArgTypes(lua_State* state, MemType T::* mptr, int opt_count = 0)
 		{
 			if (lua_gettop(state) >= 2)
@@ -167,7 +167,7 @@ namespace kaguya
 			return  lua_type_traits<T>::checkType(state, 1);
 		}
 		template<class MemType, class T>
-		typename traits::enable_if<traits::is_member_object_pointer<MemType T::*>::value, bool>::type
+		typename traits::enable_if<traits::is_object<MemType>::value, bool>::type
 		 strictCheckArgTypes(lua_State* state, MemType T::* mptr, int opt_count = 0)
 		{
 			if (lua_gettop(state) == 2)
@@ -179,19 +179,19 @@ namespace kaguya
 			return  lua_type_traits<T>::strictCheckType(state, 1);
 		}
 		template<class MemType, class T>
-		typename traits::enable_if<traits::is_member_object_pointer<MemType T::*>::value, std::string>::type
+		typename traits::enable_if<traits::is_object<MemType>::value, std::string>::type
 		argTypesName(MemType T::* mptr)
 		{
 			return util::pretty_name(typeid(T*)) + ",[OPT] " + util::pretty_name(typeid(MemType));
 		}
 		template<class MemType, class T>
-		typename traits::enable_if<traits::is_member_object_pointer<MemType T::*>::value, int>::type
+		typename traits::enable_if<traits::is_object<MemType>::value, int>::type
 		minArgCount(MemType T::* mptr)
 		{
 			return 1;
 		}
 		template<class MemType, class T>
-		typename traits::enable_if<traits::is_member_object_pointer<MemType T::*>::value, int>::type
+		typename traits::enable_if<traits::is_object<MemType>::value, int>::type
 		maxArgCount(MemType T::* mptr)
 		{
 			return 2;

--- a/include/kaguya/traits.hpp
+++ b/include/kaguya/traits.hpp
@@ -16,65 +16,54 @@ namespace kaguya
 	namespace traits
 	{
 		using standard::integral_constant;
-		using standard::is_lvalue_reference;
+		using standard::true_type;
+		using standard::false_type;
 		using standard::remove_reference;
 		using standard::remove_pointer;
+		using standard::remove_const;
+		using standard::remove_volatile;
+		using standard::remove_cv;
 		using standard::is_function;
 		using standard::is_floating_point;
 		using standard::is_integral;
 		using standard::is_enum;
 		using standard::is_convertible;
 		using standard::is_same;
-
 		using standard::is_arithmetic;
 		using standard::is_union;
 		using standard::is_class;
+		using standard::is_pointer;
+		using standard::is_member_object_pointer;
+		using standard::is_lvalue_reference;
+		using standard::is_const;
+		using standard::is_void;
+#if KAGUYA_USE_CPP11
+		using std::enable_if;
+#else
+		template<bool B, class T = void> struct enable_if: boost::enable_if_c<B, T> {};
+#endif
 
-		/// @brief same std::enable_if
-		template<bool B, class T = void>struct enable_if {};
-		/// @brief same std::enable_if
-		template<class T>struct enable_if<true, T> {
-			///@	T (defined only if Cond is true)
-			typedef T type;
-		};
-
-		/// @brief same std::is_void
-		template< typename T >
-		struct is_void :integral_constant<bool, false>
-		{
-		};
-		/// @brief same std::is_void
-		template<>
-		struct is_void<void> :integral_constant<bool, true>
-		{
-		};
-
-
-		/// @brief same std::decay
+		/// @brief Similar to std::decay but also removes const and volatile modifiers if T is neither an array nor a function
 		template< class T >
 		struct decay {
 		private:
+			///@ If T is a reference type, the type referrered to by T.	Otherwise, T.
 			typedef typename standard::remove_reference<T>::type U;
 		public:
-			///@ If T is a reference type, the type referrered to by T.	Otherwise, T.
 			typedef typename standard::conditional<
 				standard::is_array<U>::value,
 				typename standard::remove_extent<U>::type*,
 				typename standard::conditional<
-				is_function<U>::value,
-				typename standard::add_pointer<U>::type,
-				typename standard::remove_cv<U>::type
+				    is_function<U>::value,
+				    typename standard::add_pointer<U>::type,
+				    typename standard::remove_cv<U>::type
 				>::type
 			>::type type;
 		};
 
-		/// @brief same std::is_const
-		template<class T> struct is_const : integral_constant<bool, false> {};
-		template<class T> struct is_const<const T> : integral_constant<bool, true> {};
-
 		/// @brief Trait class that identifies whether T is a const reference type.
-		template<class T> struct is_const_reference : integral_constant<bool, false> {};
-		template<class T> struct is_const_reference<const T&> : integral_constant<bool, true> {};
+		template<class T> struct is_const_reference : false_type {};
+		template<class T> struct is_const_reference<const T&> : true_type {};
 
 		/// @brief Obtains the type T without top-level const and reference.
 		template< typename T >
@@ -115,38 +104,12 @@ namespace kaguya
 		};
 
 		/// @brief Trait class that identifies whether T is a std::vector type.
-		template<class T> struct is_std_vector : integral_constant<bool, false> {};
-		template<class T, class A> struct is_std_vector<std::vector<T, A> > : integral_constant<bool, true> {};
+		template<class T> struct is_std_vector : false_type {};
+		template<class T, class A> struct is_std_vector<std::vector<T, A> > : true_type {};
 
 		/// @brief Trait class that identifies whether T is a std::map type.
-		template<class T> struct is_std_map : integral_constant<bool, false> {};
-		template<class K, class V, class C, class A> struct is_std_map<std::map<K, V, C, A> > : integral_constant<bool, true> {};
-
-
-
-
-		//Until Boost 1.59.0 error:'value' is not a member of 'boost::is_pointer<int() const>' 
-		template< class T > struct remove_const { typedef T type; };
-		template< class T > struct remove_const<const T> { typedef T type; };
-		template< class T > struct remove_volatile { typedef T type; };
-		template< class T > struct remove_volatile<volatile T> { typedef T type; };
-		template< class T >
-		struct remove_cv {
-			typedef typename remove_volatile<typename remove_const<T>::type>::type type;
-		};
-
-		template< class T > struct is_pointer_helper : integral_constant<bool, false> {};
-		template< class T > struct is_pointer_helper<T*> : integral_constant<bool, true> {};
-		template< class T > struct is_pointer : is_pointer_helper<typename remove_cv<T>::type> {};
-
-		template< class T >
-		struct is_object : integral_constant<bool,
-			standard::is_arithmetic<T>::value ||
-			is_enum<T>::value ||
-			is_pointer<T>::value ||
-			standard::is_array<T>::value ||
-			standard::is_union<T>::value ||
-			standard::is_class<T>::value> {};
+		template<class T> struct is_std_map : false_type {};
+		template<class K, class V, class C, class A> struct is_std_map<std::map<K, V, C, A> > : true_type {};
 
 	}
 
@@ -178,9 +141,9 @@ namespace kaguya
 
 	/// @brief Trait class that identifies whether T is a userdata type.
 	template< typename T, typename Enable = void>
-	struct is_usertype : traits::integral_constant<bool, false> {};
+	struct is_usertype : traits::false_type {};
 	template< typename T>
-	struct is_usertype<T, typename lua_type_traits<T>::Registerable> : traits::integral_constant<bool, true> {};
+	struct is_usertype<T, typename lua_type_traits<T>::Registerable> : traits::true_type {};
 
 	/// @brief Trait class that identifies whether T is a registerable by UserdataMetatable.
 	template< typename T>

--- a/include/kaguya/traits.hpp
+++ b/include/kaguya/traits.hpp
@@ -33,7 +33,6 @@ namespace kaguya
 		using standard::is_union;
 		using standard::is_class;
 		using standard::is_pointer;
-		using standard::is_member_object_pointer;
 		using standard::is_lvalue_reference;
 		using standard::is_const;
 		using standard::is_void;
@@ -42,6 +41,15 @@ namespace kaguya
 #else
 		template<bool B, class T = void> struct enable_if: boost::enable_if_c<B, T> {};
 #endif
+
+        class Helper{};
+        /// @brief Check if T_Mem is a member object of a type. That is true if it is not a member function
+        /// Required as MSVC throws a COMDAT error when using is_member_object_pointer
+        template<typename T_Mem>
+        struct is_object{
+            typedef typename standard::is_member_function_pointer<T_Mem Helper::*>::type NotResult;
+            enum{ value = !NotResult::value };
+        };
 
 		/// @brief Similar to std::decay but also removes const and volatile modifiers if T is neither an array nor a function
 		template< class T >


### PR DESCRIPTION
Also remove identical traits from standard

This might fix #49 but I could not test it yet (need the patch merged)

Note: `traits::decay` has a heavy difference to the `std::decay` is it also removes `const volatile`. I'm not completely sure, but this might allow `std::shared_ptr<int> ptr = [std::shared_ptr<const int> from lua]` which is clearly wrong. Fixing that is quite difficult w/o a good understanding of all those kaguya functions