### PR TITLE
fixed declaration of MultipleBase for CPP11 usage

### DIFF
--- a/include/kaguya/deprecated_metatable.hpp
+++ b/include/kaguya/deprecated_metatable.hpp
@@ -265,12 +265,8 @@ namespace kaguya
 		}
 #if KAGUYA_USE_CPP11
 
-		template<typename Base>
-		void metatables(lua_State* state, LuaTable& metabases, PointerConverter& pvtreg, types::typetag<MultipleBase<Base> >)const
+		void metatables(lua_State* state, LuaTable& metabases, PointerConverter& pvtreg, types::typetag<MultipleBase<> >)const
 		{
-			class_userdata::get_metatable<Base>(state);
-			metabases.setField(metabases.size() + 1, LuaTable(state, StackTop()));
-			pvtreg.add_type_conversion<Base, class_type>();
 		}
 		template<typename Base, typename... Remain>
 		void metatables(lua_State* state, LuaTable& metabases, PointerConverter& pvtreg, types::typetag<MultipleBase<Base, Remain...> >)const

--- a/include/kaguya/metatable.hpp
+++ b/include/kaguya/metatable.hpp
@@ -21,15 +21,19 @@
 
 namespace kaguya
 {
-
+#if KAGUYA_USE_CPP11
+	template<class... Args>
+	struct MultipleBase {
+	};
+#else
 #define KAGUYA_PP_STRUCT_TDEF_REP(N) KAGUYA_PP_CAT(class A,N) = void
 #define KAGUYA_PP_STRUCT_TEMPLATE_DEF_REPEAT(N) KAGUYA_PP_REPEAT_ARG(N,KAGUYA_PP_STRUCT_TDEF_REP)
-
 	template<KAGUYA_PP_STRUCT_TEMPLATE_DEF_REPEAT(KAGUYA_CLASS_MAX_BASE_CLASSES)>
 	struct MultipleBase {
 	};
 #undef KAGUYA_PP_STRUCT_TDEF_REP
 #undef KAGUYA_PP_STRUCT_TEMPLATE_DEF_REPEAT
+#endif
 }
 
 #include "kaguya/deprecated_metatable.hpp"

--- a/include/kaguya/metatable.hpp
+++ b/include/kaguya/metatable.hpp
@@ -564,12 +564,8 @@ namespace kaguya
 		}
 #if KAGUYA_USE_CPP11
 
-		template<typename Base>
-		void metatables(lua_State* state, LuaStackRef& metabases, PointerConverter& pvtreg, types::typetag<MultipleBase<Base> >)const
+		void metatables(lua_State* state, LuaStackRef& metabases, PointerConverter& pvtreg, types::typetag<MultipleBase<> >)const
 		{
-			class_userdata::get_metatable<Base>(state);
-			metabases.setRawField(metabases.size() + 1, LuaTable(state, StackTop()));
-			pvtreg.add_type_conversion<Base, class_type>();
 		}
 		template<typename Base, typename... Remain>
 		void metatables(lua_State* state, LuaStackRef& metabases, PointerConverter& pvtreg, types::typetag<MultipleBase<Base, Remain...> >)const


### PR DESCRIPTION
`KAGUYA_PP_*` macros are not available if `KAGUYA_USE_CPP11` is defined. `MultipleBase` can easily be declared as a variadic template struct instead.